### PR TITLE
Laravel 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }],
     "require": {
         "php": "^7.2.5",
-        "africastalking/africastalking": "@dev",
+        "appslabke/africastalking": "^2.5.1",
         "guzzlehttp/guzzle": "^7.0.1",
         "illuminate/notifications": "~5.5 || ~6.0 || ~7.0 || ^8.0",
         "illuminate/support": "~5.5 || ~6.0 || ~7.0 ||  ^8.0"
@@ -48,12 +48,6 @@
             "providers": [
                 "NotificationChannels\\AfricasTalking\\AfricasTalkingServiceProvider"
             ]
-        }
-    },
-    "repositories": {
-        "local": {
-            "type": "path",
-            "url": "/home/kodaTheCoder/dev/laravel/packages/africastalking-php"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.3.1",
-        "phpunit/phpunit": "^9.0",
+        "phpunit/phpunit": "^8.0 || ^9.0",
         "orchestra/testbench": "~5.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     }],
     "require": {
         "php": "^7.2.5",
-        "appslabke/africastalking": "^2.5.1",
-        "guzzlehttp/guzzle": "^7.0.1",
+        "africastalking/africastalking": "^3.0",
+        "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "illuminate/notifications": "~5.5 || ~6.0 || ~7.0 || ^8.0",
         "illuminate/support": "~5.5 || ~6.0 || ~7.0 ||  ^8.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,22 +10,21 @@
     ],
     "homepage": "https://github.com/laravel-notification-channels/africastalking",
     "license": "MIT",
-    "authors": [
-        {
-            "name": "Osaigbovo Emmanuel",
-            "email": "osaigbovoemmanuel1@gmail.com",
-            "role": "Developer"
-        }
-    ],
+    "authors": [{
+        "name": "Osaigbovo Emmanuel",
+        "email": "osaigbovoemmanuel1@gmail.com",
+        "role": "Developer"
+    }],
     "require": {
         "php": "^7.2.5",
-        "africastalking/africastalking": "^2.3",
-        "illuminate/notifications": "~5.5 || ~6.0 || ~7.0",
-        "illuminate/support": "~5.5 || ~6.0 || ~7.0"
+        "africastalking/africastalking": "@dev",
+        "guzzlehttp/guzzle": "^7.0.1",
+        "illuminate/notifications": "~5.5 || ~6.0 || ~7.0 || ^8.0",
+        "illuminate/support": "~5.5 || ~6.0 || ~7.0 ||  ^8.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.1",
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^9.0",
         "orchestra/testbench": "~5.0"
     },
     "autoload": {
@@ -49,6 +48,12 @@
             "providers": [
                 "NotificationChannels\\AfricasTalking\\AfricasTalkingServiceProvider"
             ]
+        }
+    },
+    "repositories": {
+        "local": {
+            "type": "path",
+            "url": "/home/kodaTheCoder/dev/laravel/packages/africastalking-php"
         }
     }
 }


### PR DESCRIPTION
#### Changes made
- Added support for laravel ^8.0
- Added support for illuminate/support ^8.0
- Added support for illuminate/notifications ^8.0
- Added support for guzzlehttp/guzzle ^7.0

Changed AfricasTalkingLtd/africastalking-php package to appslabke/africastalkin, since Africas Talking is delaying PRs merge