### PR TITLE
Added support for php 8 and composer platform reqs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "role": "Developer"
     }],
     "require": {
-        "php": "^7.2.5 || ^8.0",
+        "php": ">=7.2.5",
         "africastalking/africastalking": "^3.0",
         "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "illuminate/notifications": "~5.5 || ~6.0 || ~7.0 || ^8.0",


### PR DESCRIPTION
- Fixed 'laravel-notification-channels/africastalking V2.1.0 requires php ^7.2.5 -> your php version (8.0.3) does not satisfy that requirement.'