### PR TITLE
Automate Package Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,19 +41,14 @@ The service provider gets loaded automatically.
 You will need to [Register](https://account.africastalking.com/auth/register/) and then go to your sandbox app [Go To SandBox App](https://account.africastalking.com/apps/sandbox). [Click on settings](https://account.africastalking.com/apps/sandbox/settings/key) Within this page, you will generate your `Username and key`. Place them inside your `.env` file. Remember to add your Sender ID that you will be using to send the messages. 
 
 ```bash
-AT_USERNAME=""
-AT_KEY=""
-AT_FROM=""
+AFRICASTALKING_USERNAME=""
+AFRICASTALKING_KEY=""
+AFRICASTALKING_FROM=""
 ```
-
-To load them, add this to your `config/services.php` . This will load the AfricasTalking  data from the `.env` file.file:
-
-```php
-'africastalking' => [
-    'username'      => env('AT_USERNAME'),
-    'key'           => env('AT_KEY'),
-    'from'          => env('AT_FROM'),
-]
+ 
+You can publish the package configuration file:
+```bash 
+php artisan vendor:publish --provider="NotificationChannels\AfricasTalking\AfricasTalkingServiceProvider" --tag="config"
 ```
 
 Add the `routeNotifcationForAfricasTalking` method on your notifiable Model. If this is not added,

--- a/config/africastalking.php
+++ b/config/africastalking.php
@@ -1,20 +1,19 @@
 <?php
 
 return [
-
-    /**
+    /*
      * Username from Africastalking
-     * 
+     *
      */
     'username' => env('AFRICASTALKING_USERNAME'),
 
-    /**
+    /*
      * Api key from Africastalking
      *
      */
     'key' => env('AFRICASTALKING_KEY'),
 
-    /**
+    /*
      * Shortcode for sending SMS from Africastalking
      *
      */

--- a/config/africastalking.php
+++ b/config/africastalking.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /**
+     * Username from Africastalking
+     *
+     */
+    'username' => env('AFRICASTALKING_USERNAME'),
+
+    /**
+     * Api key from Africastalking
+     *
+     */
+    'key' => env('AFRICASTALKING_KEY'),
+
+    /**
+     * Shortcode for sending SMS from Africastalking
+     *
+     */
+    'from' => env('AFRICASTALKING_FROM'),
+];

--- a/config/africastalking.php
+++ b/config/africastalking.php
@@ -4,19 +4,16 @@ return [
 
     /**
      * Username from Africastalking
-     *
      */
     'username' => env('AFRICASTALKING_USERNAME'),
 
     /**
      * Api key from Africastalking
-     *
      */
     'key' => env('AFRICASTALKING_KEY'),
 
     /**
      * Shortcode for sending SMS from Africastalking
-     *
      */
     'from' => env('AFRICASTALKING_FROM'),
 ];

--- a/config/africastalking.php
+++ b/config/africastalking.php
@@ -4,16 +4,19 @@ return [
 
     /**
      * Username from Africastalking
+     * 
      */
     'username' => env('AFRICASTALKING_USERNAME'),
 
     /**
      * Api key from Africastalking
+     *
      */
     'key' => env('AFRICASTALKING_KEY'),
 
     /**
      * Shortcode for sending SMS from Africastalking
+     *
      */
     'from' => env('AFRICASTALKING_FROM'),
 ];

--- a/src/AfricasTalkingChannel.php
+++ b/src/AfricasTalkingChannel.php
@@ -22,7 +22,7 @@ class AfricasTalkingChannel
      * Send the given notification.
      *
      * @param mixed $notifiable
-     * @param \Illuminate\Notifications\Notification $notification
+     *
      * @throws CouldNotSendNotification
      */
     public function send($notifiable, Notification $notification)
@@ -35,9 +35,9 @@ class AfricasTalkingChannel
 
         try {
             $this->africasTalking->sms()->send([
-                'to' => $phoneNumber,
+                'to'      => $phoneNumber,
                 'message' => $message->getContent(),
-                'from' => $message->getSender(),
+                'from'    => $message->getSender(),
             ]);
         } catch (Exception $e) {
             throw CouldNotSendNotification::serviceRespondedWithAnError($e->getMessage());

--- a/src/AfricasTalkingMessage.php
+++ b/src/AfricasTalkingMessage.php
@@ -12,10 +12,6 @@ class AfricasTalkingMessage
 
     /**
      * Set content for this message.
-     *
-     * @param string $content
-     * 
-     * @return this
      */
     public function content(string $content): self
     {
@@ -26,9 +22,6 @@ class AfricasTalkingMessage
 
     /**
      * Set sender for this message.
-     *
-     * @param string $from
-     * @return self
      */
     public function from(string $from): self
     {

--- a/src/AfricasTalkingMessage.php
+++ b/src/AfricasTalkingMessage.php
@@ -53,6 +53,6 @@ class AfricasTalkingMessage
      */
     public function getSender()
     {
-        return $this->from ?? config('services.africastalking.from');
+        return $this->from ?? config('africastalking.from');
     }
 }

--- a/src/AfricasTalkingMessage.php
+++ b/src/AfricasTalkingMessage.php
@@ -14,6 +14,7 @@ class AfricasTalkingMessage
      * Set content for this message.
      *
      * @param string $content
+     * 
      * @return this
      */
     public function content(string $content): self

--- a/src/AfricasTalkingServiceProvider.php
+++ b/src/AfricasTalkingServiceProvider.php
@@ -13,23 +13,36 @@ class AfricasTalkingServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__ . '/../config/africastalking.php' => config_path('africastalking.php'),
+            ], 'config');
+        }
+
         /**
          * Bootstrap the application services.
          */
         $this->app->when(AfricasTalkingChannel::class)
             ->needs(AfricasTalkingSDK::class)
             ->give(function () {
-                $userName = config('services.africastalking.username');
-                $key = config('services.africastalking.key');
-                if (is_null($userName) || is_null($key)) {
+                $username = config('africastalking.username');
+                $key = config('africastalking.key');
+
+                if (is_null($username) || is_null($key)) {
                     throw InvalidConfiguration::configurationNotSet();
                 }
-                $at = new AfricasTalkingSDK(
-                    $userName,
-                    $key
-                );
 
-                return $at;
+                return new AfricasTalkingSDK($username, $key);
             });
+    }
+
+
+    /**
+     * Register the application services.
+     */
+    public function register()
+    {
+        // Automatically apply the package configuration
+        $this->mergeConfigFrom(__DIR__.'/../config/africastalking.php', 'africastalking');
     }
 }

--- a/src/AfricasTalkingServiceProvider.php
+++ b/src/AfricasTalkingServiceProvider.php
@@ -15,11 +15,11 @@ class AfricasTalkingServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__ . '/../config/africastalking.php' => config_path('africastalking.php'),
+                __DIR__.'/../config/africastalking.php' => config_path('africastalking.php'),
             ], 'config');
         }
 
-        /**
+        /*
          * Bootstrap the application services.
          */
         $this->app->when(AfricasTalkingChannel::class)
@@ -35,7 +35,6 @@ class AfricasTalkingServiceProvider extends ServiceProvider
                 return new AfricasTalkingSDK($username, $key);
             });
     }
-
 
     /**
      * Register the application services.

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -7,7 +7,6 @@ use Exception;
 class CouldNotSendNotification extends Exception
 {
     /**
-     * @param string $error
      * @return CouldNotSendNotification
      */
     public static function serviceRespondedWithAnError(string $error): self

--- a/tests/AfricasTalkingChannelTest.php
+++ b/tests/AfricasTalkingChannelTest.php
@@ -34,9 +34,7 @@ class AfricasTalkingChannelTest extends TestCase
     /** @test */
     public function it_can_send_sms_notification()
     {
-        $this->africasTalking->shouldReceive('send')
-            ->once()
-            ->andReturn(200);
+        $this->africasTalking->shouldReceive('send')->once()->andReturn(200);
 
         $this->channel->send(new TestNotifiable, new TestNotification);
     }

--- a/tests/AfricasTalkingMessageTest.php
+++ b/tests/AfricasTalkingMessageTest.php
@@ -13,7 +13,7 @@ class AfricasTalkingMessageTest extends TestCase
     {
         parent::setUp();
         $this->message = new AfricasTalkingMessage();
-        config(['services.africastalking.from' => 'AFRICASTKNG']);
+        config(['africastalking.from' => 'AFRICASTKNG']);
     }
 
     /** @test */


### PR DESCRIPTION
This PR sets up a configuration file for this package. This means users will no longer need to manually set the package configuration inside the `configs/service` file. This also allows the package config to be publishable by the user.

I have also updated the package ReadMe file to reflect this changes.

PS: This PR follows the default Laravel code conventions.