### PR TITLE
Support AfricasTalkingChannel::class

### DIFF
--- a/src/AfricasTalkingChannel.php
+++ b/src/AfricasTalkingChannel.php
@@ -30,13 +30,7 @@ class AfricasTalkingChannel
     {
         $message = $notification->toAfricasTalking($notifiable);
 
-        if (!$phoneNumber = $notifiable->routeNotificationFor('africasTalking')) {
-            $phoneNumber = $notifiable->phone_number;
-        }
-
-        if(!empty($message->getTo())) {
-            $phoneNumber = $message->getTo();
-        }
+        $phoneNumber = $this->getTo($notifiable, $notification, $message);
 
         if(empty($phoneNumber)) {
             throw InvalidPhonenumber::configurationNotSet();
@@ -60,5 +54,27 @@ class AfricasTalkingChannel
         } catch (Exception $e) {
             throw CouldNotSendNotification::serviceRespondedWithAnError($e->getMessage());
         }
+    }
+
+
+    private function getTo($notifiable, Notification $notification, AfricasTalkingMessage $message)
+    {
+        if(!empty($message->getTo())) {
+            return $message->getTo();
+        }
+
+        if ($notifiable->routeNotificationFor(static::class, $notification)) {
+            return $notifiable->routeNotificationFor(static::class, $notification);
+        }
+
+        if ($notifiable->routeNotificationFor('africasTalking', $notification)) {
+            return $notifiable->routeNotificationFor('africasTalking', $notification);
+        }
+
+        if (isset($notifiable->phone_number)) {
+            return $notifiable->phone_number;
+        }
+
+        throw CouldNotSendNotification::invalidReceiver();
     }
 }

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -14,4 +14,11 @@ class CouldNotSendNotification extends Exception
     {
         return new static("AfricasTalking service responded with an error: {$error}");
     }
+
+
+    public static function invalidReceiver(): self
+    {
+        return new static("The notifiable did not have a receiving phone number. Add a routeNotificationForAfricasTalking
+            method or a phone_number attribute to your notifiable.");
+    }
 }

--- a/tests/AfricasTalkingChannelTest.php
+++ b/tests/AfricasTalkingChannelTest.php
@@ -3,6 +3,8 @@
 namespace NotificationChannels\AfricasTalking\Test;
 
 use AfricasTalking\SDK\AfricasTalking as AfricasTalkingSDK;
+use AfricasTalking\SDK\SMS;
+use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Notifications\Notification;
 use Mockery;
 use NotificationChannels\AfricasTalking\AfricasTalkingChannel;
@@ -14,13 +16,14 @@ class AfricasTalkingChannelTest extends TestCase
     /** @var Mockery\Mock */
     protected $africasTalking;
 
-    /** @var \NotificationChannels\Twitter\AfricasTalkingChannel */
+    /** @var \NotificationChannels\AfricasTalking\AfricasTalkingChannel */
     protected $channel;
 
     public function setUp(): void
     {
         parent::setUp();
         $this->africasTalking = Mockery::mock(AfricasTalkingSDK::class);
+        $this->sms = Mockery::mock(SMS::class);
         $this->channel = new AfricasTalkingChannel($this->africasTalking);
     }
 
@@ -32,17 +35,77 @@ class AfricasTalkingChannelTest extends TestCase
     }
 
     /** @test */
-    public function it_can_send_sms_notification()
+    public function it_can_send_sms_notification_to_notifiable_with_method()
     {
-        $this->africasTalking->shouldReceive('send')
+        $this->africasTalking->expects('sms')
+            ->once()
+            ->andReturn($this->sms);
+
+        $this->sms->expects('send')
             ->once()
             ->andReturn(200);
 
-        $this->channel->send(new TestNotifiable, new TestNotification);
+        $this->channel->send(new NotifiableWithMethod, new TestNotification);
+    }
+
+    /** @test */
+    public function it_can_send_sms_notification_to_anonymous_notifiable_using_class_name()
+    {
+        $this->africasTalking->expects('sms')
+            ->once()
+            ->andReturn($this->sms);
+
+        $this->sms->expects('send')
+            ->once()
+            ->andReturn(200);
+
+        $this->channel->send((new AnonymousNotifiable())->route(AfricasTalkingChannel::class, "+1111111111"), new TestNotification);
+    }
+
+    /** @test */
+    public function it_can_send_sms_notification_to_anonymous_notifiable_using_string_name()
+    {
+        $this->africasTalking->expects('sms')
+            ->once()
+            ->andReturn($this->sms);
+
+        $this->sms->expects('send')
+            ->once()
+            ->andReturn(200);
+
+        $this->channel->send((new AnonymousNotifiable())->route('africasTalking', "+1111111111"), new TestNotification);
+    }
+
+    /** @test */
+    public function it_can_send_sms_notification_to_notifiable_with_attribute()
+    {
+        $this->africasTalking->expects('sms')
+            ->once()
+            ->andReturn($this->sms);
+
+        $this->sms->expects('send')
+            ->once()
+            ->andReturn(200);
+
+        $this->channel->send(new NotifiableWithAttribute(), new TestNotification);
+    }
+
+    /** @test */
+    public function it_can_send_sms_notification_to_message_get_to()
+    {
+        $this->africasTalking->expects('sms')
+            ->once()
+            ->andReturn($this->sms);
+
+        $this->sms->expects('send')
+            ->once()
+            ->andReturn(200);
+
+        $this->channel->send(new AnonymousNotifiable(), new TestNotificationWithGetTo);
     }
 }
 
-class TestNotifiable
+class NotifiableWithMethod
 {
     use \Illuminate\Notifications\Notifiable;
 
@@ -65,5 +128,38 @@ class TestNotification extends Notification
     public function toAfricasTalking($notifiable)
     {
         return new AfricasTalkingMessage();
+    }
+}
+
+class TestNotificationWithGetTo extends Notification
+{
+    /**
+     * @param $notifiable
+     * @return AfricasTalkingMessage
+     * @throws CouldNotSendNotification
+     */
+    public function toAfricasTalking($notifiable)
+    {
+        return (new AfricasTalkingMessage())
+            ->to('+22222222222');
+    }
+}
+
+
+class Notifiable
+{
+    public $phone_number = null;
+
+    public function routeNotificationFor()
+    {
+    }
+}
+
+class NotifiableWithAttribute
+{
+    public $phone_number = '+22222222222';
+
+    public function routeNotificationFor()
+    {
     }
 }


### PR DESCRIPTION
Hello,

When sending an SMS to a phone number only using `AfricasTalkingChannel::class`, it throws an exception because AnonymousNotifiable's routes array has `AfricasTalkingChannel::class` whereas it does not have `africasTalking`.
```
Notification::route(AfricasTalkingChannel::class, '+11111')->send(new SomeNotification())
```
However, the channel only supports the string format i.e. `africasTalking`.

This PR adds this ability.