### PR TITLE
support minor updates of laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "php": ">=7.2.5",
         "africastalking/africastalking": "^3.0",
         "guzzlehttp/guzzle": "^6.2 || ^7.0",
-        "illuminate/notifications": "5.5 - 10.0",
-        "illuminate/support": "5.5 - 10.0"
+        "illuminate/notifications": "5.5 - 10",
+        "illuminate/support": "5.5 - 10"
     },
     "require-dev": {
         "mockery/mockery": "^1.3",


### PR DESCRIPTION
The support for laravel 10 added by #24 was for only laravel 10.0, which makes the package not usable on other versions of laravel 10. 
![image](https://github.com/laravel-notification-channels/africastalking/assets/53460169/fd298a00-368c-4456-b6b6-4522775a886b)


The changes in this PR allows for the package to be used in all versions of laravel 10